### PR TITLE
allow non-breaking tcpdf upgrades

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
 	],
 	"require": {
 		"php": ">=5.3.0",
-        	"tecnickcom/tcpdf": "6.2.*"
+        	"tecnickcom/tcpdf": "^6.2.1"
 	},
 	"autoload": {
 		"classmap": [


### PR DESCRIPTION
This PR relaxes the version requirement for `tcpdf`, specifically 6.4.3, effectively enabling the package to be used with PHP 7.4.