### PR TITLE
Remove version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,5 @@
 {
 	"name": "rafikhaceb/tcpdi",
-	"version": "1.0.5",
 	"type": "library",
 	"description": "TCPDI is a PHP class for importing PDF to use with TCPDF",
 	"keywords": ["PDF", "tcpdi", "tcpdi_parser", "tcpdf"],


### PR DESCRIPTION
It's not necessary

> Optional if the package repository can infer the version from somewhere, such as the VCS tag name in the VCS repository. In that case it is also recommended to omit it.

https://getcomposer.org/doc/04-schema.md#version