### PR TITLE
Fix deprecation notice when used in a Symfony application

### DIFF
--- a/fpdf_tpl.php
+++ b/fpdf_tpl.php
@@ -306,6 +306,7 @@ class FPDF_TPL extends FPDF
 
     /**
      * See FPDF/TCPDF-Documentation ;-)
+     * @return mixed
      */
     public function Image(
         $file,


### PR DESCRIPTION
When using this library in a Symfony application the following deprecation notice is raised:

```
deprecation.INFO: User Deprecated: Method "TCPDF::Image()" might add "mixed" as a native return type declaration in the future. Do the same in child class "FPDF_TPL" now to avoid errors or add an explicit @return annotation to suppress this message.
```